### PR TITLE
[Shrink] Reduce docker image size for Go 1.14 alpine and goimports image

### DIFF
--- a/alpine-go114-goimports/Dockerfile
+++ b/alpine-go114-goimports/Dockerfile
@@ -4,23 +4,25 @@ MAINTAINER Dan Belden <me@danbelden.com>
 # Set build configs
 ENV GO_INSTALL_ROOT /usr/local
 ENV GO_PATH /go
-ENV GO_VERSION 1.14.6
+ENV GO_VERSION 1.14.9
 
 # Install go
-RUN apk upgrade --update --no-cache
-RUN apk add --no-cache --virtual ".build-deps" go gcc bash musl-dev openssl-dev ca-certificates
-RUN wget -O go.tgz "https://dl.google.com/go/go${GO_VERSION}.src.tar.gz"
-RUN tar -C $GO_INSTALL_ROOT -xzf go.tgz && rm go.tgz
-RUN cd $GO_INSTALL_ROOT/go/src && ./make.bash
+RUN apk upgrade --update --no-cache && \
+  apk add --no-cache --virtual ".build-deps" go gcc bash musl-dev openssl-dev ca-certificates && \
+  wget -O go.tgz "https://dl.google.com/go/go${GO_VERSION}.src.tar.gz" && \
+  tar -C $GO_INSTALL_ROOT -xzf go.tgz && \
+  rm go.tgz && \
+  cd $GO_INSTALL_ROOT/go/src && \
+  ./make.bash && \
+  apk del ".build-deps"
 ENV GOROOT="${GO_INSTALL_ROOT}/go"
 ENV GOPATH="${GO_PATH}"
 ENV PATH="${PATH}:${GOROOT}/bin:${GOPATH}/bin"
-RUN apk del ".build-deps"
 
 # Install goimports
-RUN apk add --no-cache --virtual ".build-deps" git
-RUN go get golang.org/x/tools/cmd/goimports
-RUN apk del ".build-deps"
+RUN apk add --no-cache --virtual ".build-deps" git && \
+  go get golang.org/x/tools/cmd/goimports && \
+  apk del ".build-deps"
 
 # Create empty workdir
 RUN mkdir -p /app


### PR DESCRIPTION
## Overview

Reduce docker image from `913MB` to `429MB` 🚀  😎  😁 

## Log

```
$ docker images
REPOSITORY                                    TAG                     IMAGE ID            CREATED             SIZE
danbelden/alpine-go114-goimports              test                    c321cbd3ca2d        11 minutes ago      429MB
danbelden/alpine-go114-goimports              latest                  790b8c125a51        34 minutes ago      913MB
...
```